### PR TITLE
Localizations when using iNotify in a Bundle

### DIFF
--- a/iNotify/iNotify.h
+++ b/iNotify/iNotify.h
@@ -134,6 +134,7 @@ static NSString *const iNotifyMessageMaxVersionKey = @"MaxVersion";
     id<iNotifyDelegate> __ah_weak _delegate;
     id _visibleAlert;
     BOOL _currentlyChecking;
+    NSImage *_customIcon;
 }
 #endif
 
@@ -169,6 +170,8 @@ static NSString *const iNotifyMessageMaxVersionKey = @"MaxVersion";
 @property (nonatomic, strong) NSDate *lastChecked;
 @property (nonatomic, strong) NSDate *lastReminded;
 @property (nonatomic, ah_weak) id<iNotifyDelegate> delegate;
+
+@property (nonatomic, strong) NSImage *customIcon;
 
 //manually control behaviour
 - (NSString *)nextNotificationInDict:(NSDictionary *)dict;

--- a/iNotify/iNotify.m
+++ b/iNotify/iNotify.m
@@ -84,6 +84,7 @@ static iNotify *sharedInstance = nil;
 @synthesize delegate = _delegate;
 @synthesize visibleAlert = _visibleAlert;
 @synthesize currentlyChecking = _currentlyChecking;
+@synthesize customIcon = _customIcon;
 
 + (iNotify *)sharedInstance
 {
@@ -442,6 +443,10 @@ static iNotify *sharedInstance = nil;
                                                   alternateButton:nil
                                                       otherButton:nil
                                         informativeTextWithFormat:@"%@", message];
+            }
+            
+            if (self.customIcon) {
+                [self.visibleAlert setIcon:self.customIcon];
             }
             
             [self.visibleAlert beginSheetModalForWindow:[[NSApplication sharedApplication] mainWindow]

--- a/iNotify/iNotify.m
+++ b/iNotify/iNotify.m
@@ -100,7 +100,7 @@ static iNotify *sharedInstance = nil;
     if (bundle == nil)
     {
         //get localisation bundle
-        NSString *bundlePath = [[NSBundle mainBundle] pathForResource:@"iNotify" ofType:@"bundle"];
+        NSString *bundlePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"iNotify" ofType:@"bundle"];
         bundle = [NSBundle bundleWithPath:bundlePath] ?: [NSBundle mainBundle];
 
         //get correct lproj folder as this doesn't always happen automatically


### PR DESCRIPTION
I use iNotify in a screensaver bundle. I faced the problem that the bundled Localizable.strings are not working, because they are not found. To fix this i change `[Bundle  mainBundle]` to `[Bundle bundleForClass:self]`
