### PR TITLE
Eliminate UILineBreakModeWordWrap deprecated warning

### DIFF
--- a/iNotify/iNotify.m
+++ b/iNotify/iNotify.m
@@ -580,7 +580,7 @@ static iNotify *sharedInstance = nil;
                 if ([label.text isEqualToString:alertView.message])
                 {
                     label.alpha = 1.0f;
-                    label.lineBreakMode = UILineBreakModeWordWrap;
+                    label.lineBreakMode = NSLineBreakByWordWrapping;
                     label.numberOfLines = 0;
                     [label sizeToFit];
                     offset = label.frame.size.height - frame.size.height;


### PR DESCRIPTION
Replaces UILineBreakModeWordWrap with NSLineBreakByWordWrapping.
